### PR TITLE
feat(nav/admin): Account dropdown, region filters; admin selects; degree normalization; difficulty CSV (closes #81)

### DIFF
--- a/__tests__/api/admin/schools.vitest.ts
+++ b/__tests__/api/admin/schools.vitest.ts
@@ -103,7 +103,7 @@ describe('Schools Admin API', () => {
             data: {
               id: 'school-123',
               name: 'Test University',
-              country: 'USA',
+              region: 'United States',
               created_by: 'admin-123'
             },
             error: null
@@ -119,7 +119,7 @@ describe('Schools Admin API', () => {
 
       const schoolData = {
         name: 'Test University',
-        country: 'USA',
+        region: 'United States',
         type: 'Public',
         location: 'New York'
       }
@@ -135,7 +135,7 @@ describe('Schools Admin API', () => {
         name: 'Test University',
         initial: null,
         type: 'Public',
-        country: 'USA',
+        region: 'United States',
         location: 'New York',
         year_founded: null,
         qs_ranking: null,
@@ -173,7 +173,7 @@ describe('Schools Admin API', () => {
       mockGetCurrentUser.mockResolvedValue({ id: 'admin-123' } as any)
       mockIsAdmin.mockResolvedValue(true)
 
-      const request = createRequest({ country: 'USA' }) // Missing name
+      const request = createRequest({ region: 'United States' }) // Missing name
       const response = await POST(request)
       const result = await response.json()
 
@@ -231,7 +231,7 @@ describe('Schools Admin API', () => {
           data: [{
             id: 'school-123',
             name: 'Test University',
-            country: 'USA',
+            region: 'United States',
             type: 'Public'
           }],
           error: null
@@ -369,7 +369,7 @@ describe('Schools Admin API', () => {
             data: [{
               id: 'school-123',
               name: 'Updated University',
-              country: 'Canada'
+              region: 'Canada'
             }],
             error: null
           })
@@ -382,7 +382,7 @@ describe('Schools Admin API', () => {
 
       const updateData = {
         name: 'Updated University',
-        country: 'Canada',
+        region: 'Canada',
         type: 'Private'
       }
 
@@ -443,7 +443,7 @@ describe('Schools Admin API', () => {
         delete: vi.fn()
       })
 
-      const request = createPutRequest({ country: 'USA' }) // Missing name
+      const request = createPutRequest({ region: 'United States' }) // Missing name
       const params = Promise.resolve({ id: 'school-123' })
       const response = await PUT(request, { params })
       const result = await response.json()

--- a/__tests__/api/collections-items.vitest.ts
+++ b/__tests__/api/collections-items.vitest.ts
@@ -37,7 +37,7 @@ const mockCollectionItem = {
     name: 'Test School',
     initial: 'TS',
     location: 'Test City',
-    country: 'Test Country'
+    region: 'United States'
   }
 }
 

--- a/__tests__/components/navigation-client.test.tsx
+++ b/__tests__/components/navigation-client.test.tsx
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
+// Mock dropdown menu to render content inline for easier testing
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, asChild, ...props }: any) =>
+    asChild ? <>{children}</> : <button {...props}>{children}</button>,
+}))
+
+// Mock Supabase client used inside NavigationClient
+const mockGetUser = vi.fn()
+const mockFrom = vi.fn()
+const mockOnAuthStateChange = vi.fn()
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getUser: mockGetUser,
+      onAuthStateChange: mockOnAuthStateChange
+    },
+    from: mockFrom
+  })
+}))
+
+import { NavigationClient } from '@/components/navigation-client'
+
+const makeAuthMocks = (opts: { hasUser: boolean; isAdmin?: boolean }) => {
+  mockGetUser.mockResolvedValueOnce({ data: { user: opts.hasUser ? { id: 'user-1' } : null } })
+  if (opts.hasUser) {
+    mockFrom.mockReturnValueOnce({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { is_admin: !!opts.isAdmin } })
+    })
+  }
+  mockOnAuthStateChange.mockReturnValue({ data: { subscription: { unsubscribe: () => {} } } })
+}
+
+describe('NavigationClient - Account/Logout', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not submit logout form when confirmation is cancelled', async () => {
+    makeAuthMocks({ hasUser: true, isAdmin: false })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const submitSpy = vi.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation(() => {})
+
+    render(<NavigationClient />)
+
+    // Wait for loading state to clear
+    await waitFor(() => expect(screen.queryByText('Account')).toBeInTheDocument())
+
+    // Open Account menu
+    fireEvent.click(screen.getByRole('button', { name: 'Account' }))
+
+    // Click Logout
+    const logoutBtn = await screen.findByRole('button', { name: /logout/i })
+    fireEvent.click(logoutBtn)
+
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(submitSpy).not.toHaveBeenCalled()
+  })
+
+  it('submits logout form when confirmation is accepted', async () => {
+    makeAuthMocks({ hasUser: true, isAdmin: false })
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const submitSpy = vi.spyOn(HTMLFormElement.prototype, 'submit').mockImplementation(() => {})
+
+    render(<NavigationClient />)
+    await waitFor(() => expect(screen.queryByText('Account')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Account' }))
+    const logoutBtn = await screen.findByRole('button', { name: /logout/i })
+    fireEvent.click(logoutBtn)
+
+    expect(submitSpy).toHaveBeenCalled()
+  })
+
+  it('shows Admin item only for admin users', async () => {
+    // Non-admin
+    makeAuthMocks({ hasUser: true, isAdmin: false })
+    const { unmount } = render(<NavigationClient />)
+    await waitFor(() => expect(screen.queryByText('Account')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Account' }))
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument()
+    unmount()
+
+    // Admin
+    makeAuthMocks({ hasUser: true, isAdmin: true })
+    render(<NavigationClient />)
+    await waitFor(() => expect(screen.queryByText('Account')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Account' }))
+    expect(await screen.findByText('Admin')).toBeInTheDocument()
+  })
+})
+
+

--- a/__tests__/lib/admin-search.test.ts
+++ b/__tests__/lib/admin-search.test.ts
@@ -2,11 +2,11 @@ import { filterItems, searchConfigs, MatchType, getMatchInfo, simpleFilterItems 
 
 // Mock data for testing
 const mockSchools = [
-  { id: '1', name: 'Carnegie Mellon University', initial: 'CMU', country: 'USA', location: 'Pittsburgh' },
-  { id: '2', name: 'Massachusetts Institute of Technology', initial: 'MIT', country: 'USA', location: 'Cambridge' },
-  { id: '3', name: 'Stanford University', initial: 'Stanford', country: 'USA', location: 'Stanford' },
-  { id: '4', name: 'University of California Berkeley', initial: 'UC Berkeley', country: 'USA', location: 'Berkeley' },
-  { id: '5', name: 'Cornell University', initial: 'Cornell', country: 'USA', location: 'Ithaca' }
+  { id: '1', name: 'Carnegie Mellon University', initial: 'CMU', region: 'United States', location: 'Pittsburgh' },
+  { id: '2', name: 'Massachusetts Institute of Technology', initial: 'MIT', region: 'United States', location: 'Cambridge' },
+  { id: '3', name: 'Stanford University', initial: 'Stanford', region: 'United States', location: 'Stanford' },
+  { id: '4', name: 'University of California Berkeley', initial: 'UC Berkeley', region: 'United States', location: 'Berkeley' },
+  { id: '5', name: 'Cornell University', initial: 'Cornell', region: 'United States', location: 'Ithaca' }
 ]
 
 const mockPrograms = [
@@ -94,12 +94,12 @@ describe('Admin Search System', () => {
       expect(results.every(school => school.name.includes('University'))).toBe(true)
     })
 
-    test('should find schools by country', () => {
+    test('should find schools by region', () => {
       const results = filterItems(mockSchools, {
         fields: searchConfigs.schools.fields,
-        searchTerm: 'USA'
+        searchTerm: 'United States'
       })
-      expect(results).toHaveLength(5) // All mock schools are in USA
+      expect(results).toHaveLength(5) // All mock schools are in the United States
     })
 
     test('should find schools by location', () => {
@@ -265,13 +265,13 @@ describe('Admin Search System', () => {
         id: `${i}`,
         name: `School ${i}`,
         initial: `S${i}`,
-        country: i % 2 === 0 ? 'USA' : 'Canada'
+        region: i % 2 === 0 ? 'United States' : 'Canada'
       }))
 
       const startTime = performance.now()
       const results = filterItems(largeDataset, {
-        fields: ['name', 'initial', 'country'],
-        searchTerm: 'USA'
+        fields: ['name', 'initial', 'region'],
+        searchTerm: 'United States'
       })
       const endTime = performance.now()
 

--- a/__tests__/lib/schema-enhancements.test.ts
+++ b/__tests__/lib/schema-enhancements.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, assertType } from 'vitest'
+import {
+  APPLICATION_DIFFICULTY_VALUES,
+  DIFFICULTY_LEVELS,
+  DELIVERY_METHODS,
+  SCHEDULE_TYPES,
+  DEGREE_TYPES,
+  type ApplicationDifficulty,
+  type DifficultyInfo,
+  type ProgramSearchFilters,
+  type SchoolSearchFilters,
+  type EnhancedProgram,
+  type EnhancedSchool,
+} from '@/lib/types/schema-enhancements'
+
+describe('schema-enhancements types/constants', () => {
+  it('defines difficulty values and map coherently', () => {
+    expect(APPLICATION_DIFFICULTY_VALUES).toEqual(['SSR', 'SR', 'R', 'N'])
+    for (const key of APPLICATION_DIFFICULTY_VALUES) {
+      const info = DIFFICULTY_LEVELS[key]
+      expect(info.level).toBe(key)
+      expect(info.label.length).toBeGreaterThan(0)
+      expect(info.acceptanceRate.length).toBeGreaterThan(0)
+    }
+
+    // Type-level check
+    const sample: DifficultyInfo = DIFFICULTY_LEVELS.SR
+    expect(sample.level).toBe('SR')
+  })
+
+  it('includes expected delivery, schedule and degree options', () => {
+    expect(DELIVERY_METHODS).toContain('Onsite')
+    expect(DELIVERY_METHODS).toContain('Online')
+    expect(DELIVERY_METHODS).toContain('Hybrid')
+
+    expect(SCHEDULE_TYPES).toEqual(expect.arrayContaining(['Full-time', 'Part-time', 'Flexible']))
+
+    expect(DEGREE_TYPES).toEqual(expect.arrayContaining(['Bachelor', 'Master', 'PhD']))
+  })
+
+  it('ProgramSearchFilters supports region filtering and typed difficulty', () => {
+    const filters: ProgramSearchFilters = {
+      search: 'cs',
+      region: ['United States', 'Asia'],
+      difficulty: ['SSR', 'R'] satisfies ApplicationDifficulty[]
+    }
+    expect(filters.region?.length).toBe(2)
+    expect(filters.difficulty?.includes('SSR')).toBe(true)
+  })
+
+  it('SchoolSearchFilters supports basic constraints', () => {
+    const filters: SchoolSearchFilters = {
+      search: 'Tech',
+      type: ['Public'],
+      year_founded_min: 1800,
+      year_founded_max: 2024
+    }
+    expect(filters.type).toEqual(['Public'])
+  })
+
+  it('EnhancedProgram and EnhancedSchool minimal shape compiles', () => {
+    const p: EnhancedProgram = {
+      id: 'p1',
+      name: 'CS',
+      school_id: 's1',
+      degree: 'Master',
+      is_stem: true,
+      created_at: new Date().toISOString()
+    }
+    const s: EnhancedSchool = {
+      id: 's1',
+      name: 'Test University',
+      created_at: new Date().toISOString()
+    }
+    expect(p.name).toBe('CS')
+    expect(s.name).toBe('Test University')
+  })
+})
+
+

--- a/__tests__/lib/supabase/helpers.test.ts
+++ b/__tests__/lib/supabase/helpers.test.ts
@@ -374,7 +374,7 @@ describe('Supabase Helpers', () => {
               name: 'Harvard University',
               initial: 'HU',
               location: 'Cambridge, MA',
-              country: 'USA'
+              region: 'United States'
             },
             programs: null
           }

--- a/__tests__/schema/test-schema.sql
+++ b/__tests__/schema/test-schema.sql
@@ -21,7 +21,7 @@ VALUES ('00000000-0000-0000-0000-000000000001', 'Test Admin', true)
 ON CONFLICT (id) DO NOTHING;
 
 -- Insert a test school
-INSERT INTO schools (id, name, type, country, location, created_by)
+INSERT INTO schools (id, name, type, region, location, created_by)
 VALUES (
   '11111111-1111-1111-1111-111111111111',
   'Test University',

--- a/docs/design/schema-design.md
+++ b/docs/design/schema-design.md
@@ -15,7 +15,7 @@ Supabase's `auth.users` table will handle user data. A `profiles` table will sto
 *   `name` (text, not null)
 *   `initial` (text)
 *   `type` (text)
-*   `country` (text)
+*   `region` (enum) - One of: 'United States', 'United Kingdom', 'Canada', 'Europe', 'Asia', 'Australia', 'Other'
 *   `location` (text)
 *   `year_founded` (integer)
 *   `qs_ranking` (integer)
@@ -41,6 +41,8 @@ Supabase's `auth.users` table will handle user data. A `profiles` table will sto
 *   `location` (text) - *ADD: Program-specific location, defaults to school location*
 *   `add_ons` (jsonb) - *ADD: For storing additional structured info like scholarships*
 *   `start_date` (date) - *ADD: Program start date*
+*   `application_difficulty` (varchar) - *One of 'SSR' | 'SR' | 'R' | 'N'; indexed*
+*   `difficulty_description` (text)
 *   `created_by` (uuid, foreign key to `auth.users.id`)
 *   `created_at` (timestamp with time zone)
 

--- a/src/app/admin/csv-upload/page.tsx
+++ b/src/app/admin/csv-upload/page.tsx
@@ -45,7 +45,7 @@ export default function CSVUpload() {
                   name: school.name,
                   initial: school.initial,
                   type: school.type,
-                  country: school.country,
+                  region: school.region ?? school.country,
                   location: school.location,
                   year_founded: school.year_founded ? parseInt(school.year_founded) : null,
                   qs_ranking: school.qs_ranking ? parseInt(school.qs_ranking) : null,
@@ -203,7 +203,7 @@ export default function CSVUpload() {
                 <li>name (required)</li>
                 <li>initial</li>
                 <li>type</li>
-                <li>country</li>
+                <li>region (enum: United States, United Kingdom, Canada, Europe, Asia, Australia, Other)</li>
                 <li>location</li>
                 <li>year_founded (number)</li>
                 <li>qs_ranking (number)</li>

--- a/src/app/admin/csv-upload/page.tsx
+++ b/src/app/admin/csv-upload/page.tsx
@@ -118,6 +118,8 @@ export default function CSVUpload() {
                   delivery_method: program.delivery_method,
                   schedule_type: program.schedule_type,
                   location: program.location,
+                  application_difficulty: program.application_difficulty || null,
+                  difficulty_description: program.difficulty_description || null,
                   add_ons: program.add_ons ? (() => {
                     try {
                       return JSON.parse(program.add_ons)
@@ -239,7 +241,7 @@ export default function CSVUpload() {
                     <li>name (required)</li>
                     <li>initial</li>
                     <li>school_id (required - UUID of existing school)</li>
-                    <li>degree (required)</li>
+                  <li>degree (required; normalized to Bachelor/Master/PhD/Associate/Certificate/Diploma)</li>
                     <li>description</li>
                     <li>website_url</li>
                   </ul>
@@ -256,6 +258,8 @@ export default function CSVUpload() {
                     <li>start_date (YYYY-MM-DD)</li>
                     <li>is_stem (true/false or 1/0)</li>
                     <li>add_ons (JSON string)</li>
+                    <li>application_difficulty (SSR/SR/R/N)</li>
+                    <li>difficulty_description</li>
                   </ul>
                 </div>
                 

--- a/src/app/admin/programs/page.tsx
+++ b/src/app/admin/programs/page.tsx
@@ -85,6 +85,8 @@ async function createProgram(formData: FormData) {
     delivery_method: formData.get('delivery_method') as string,
     schedule_type: formData.get('schedule_type') as string,
     location: formData.get('location') as string,
+    application_difficulty: (formData.get('application_difficulty') as string) || null,
+    difficulty_description: (formData.get('difficulty_description') as string) || null,
     add_ons: addOns,
     start_date: formData.get('start_date') as string || null,
     created_by: user.id,
@@ -207,7 +209,15 @@ export default async function ProgramsManagementPage(props: {
                 
                 <div>
                   <Label htmlFor="degree">Degree *</Label>
-                  <Input id="degree" name="degree" placeholder="e.g., MS, PhD, BS" required />
+                  <select id="degree" name="degree" required className="w-full p-2 border border-gray-300 rounded-md">
+                    <option value="">Select degree</option>
+                    <option value="Bachelor">Bachelor</option>
+                    <option value="Master">Master</option>
+                    <option value="PhD">PhD</option>
+                    <option value="Associate">Associate</option>
+                    <option value="Certificate">Certificate</option>
+                    <option value="Diploma">Diploma</option>
+                  </select>
                 </div>
                 
                 <div className="md:col-span-2">
@@ -256,6 +266,7 @@ export default async function ProgramsManagementPage(props: {
                     <option value="Onsite">Onsite</option>
                     <option value="Online">Online</option>
                     <option value="Hybrid">Hybrid</option>
+                    <option value="Flexible">Flexible</option>
                   </select>
                 </div>
                 
@@ -265,6 +276,7 @@ export default async function ProgramsManagementPage(props: {
                     <option value="">Select schedule type</option>
                     <option value="Full-time">Full-time</option>
                     <option value="Part-time">Part-time</option>
+                    <option value="Flexible">Flexible</option>
                   </select>
                 </div>
                 
@@ -421,6 +433,22 @@ export default async function ProgramsManagementPage(props: {
                   <Label htmlFor="other_tests">Other Tests</Label>
                   <Input id="other_tests" name="other_tests" placeholder="e.g., GMAT, SAT" />
                 </div>
+
+                  <div>
+                    <Label htmlFor="application_difficulty">Application Difficulty</Label>
+                    <select id="application_difficulty" name="application_difficulty" className="w-full p-2 border border-gray-300 rounded-md">
+                      <option value="">Select difficulty</option>
+                      <option value="SSR">SSR</option>
+                      <option value="SR">SR</option>
+                      <option value="R">R</option>
+                      <option value="N">N</option>
+                    </select>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="difficulty_description">Difficulty Description</Label>
+                    <Textarea id="difficulty_description" name="difficulty_description" rows={2} />
+                  </div>
                 
                 <div className="md:col-span-2 grid grid-cols-1 md:grid-cols-3 gap-4">
                   <div className="flex items-center space-x-2">

--- a/src/app/admin/schools/page.tsx
+++ b/src/app/admin/schools/page.tsx
@@ -37,7 +37,7 @@ async function createSchool(formData: FormData) {
     name: formData.get('name') as string,
     initial: formData.get('initial') as string,
     type: formData.get('type') as string,
-    country: formData.get('country') as string,
+    region: formData.get('region') as string,
     location: formData.get('location') as string,
     year_founded: formData.get('year_founded') ? parseInt(formData.get('year_founded') as string) : null,
     qs_ranking: formData.get('qs_ranking') ? parseInt(formData.get('qs_ranking') as string) : null,
@@ -110,12 +110,26 @@ export default async function SchoolsManagementPage(props: {
             
             <div>
               <Label htmlFor="type">Type</Label>
-              <Input id="type" name="type" placeholder="e.g., University" />
+              <select id="type" name="type" className="w-full p-2 border border-gray-300 rounded-md">
+                <option value="">Select type</option>
+                <option value="Public">Public</option>
+                <option value="Private">Private</option>
+                <option value="Art & Design">Art & Design</option>
+                <option value="Community College">Community College</option>
+              </select>
             </div>
             
             <div>
-              <Label htmlFor="country">Country</Label>
-              <Input id="country" name="country" />
+              <Label htmlFor="region">Region</Label>
+              <select id="region" name="region" className="w-full p-2 border border-gray-300 rounded-md">
+                <option value="">Select region</option>
+                <option value="United States">United States</option>
+                <option value="United Kingdom">United Kingdom</option>
+                <option value="Canada">Canada</option>
+                <option value="Europe">Europe</option>
+                <option value="Asia">Asia</option>
+                <option value="Australia">Australia</option>
+              </select>
             </div>
             
             <div>

--- a/src/app/api/admin/schools/[id]/route.ts
+++ b/src/app/api/admin/schools/[id]/route.ts
@@ -87,7 +87,7 @@ export async function PUT(
       name: body.name,
       initial: body.initial || null,
       type: body.type || null,
-      country: body.country || null,
+      region: body.region || (body.country ?? null),
       location: body.location || null,
       year_founded: body.year_founded || null,
       qs_ranking: body.qs_ranking || null,

--- a/src/app/api/admin/schools/route.ts
+++ b/src/app/api/admin/schools/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
       name: body.name,
       initial: body.initial || null,
       type: body.type || null,
-      country: body.country || null,
+      region: body.region || (body.country ?? null),
       location: body.location || null,
       year_founded: body.year_founded || null,
       qs_ranking: body.qs_ranking || null,

--- a/src/app/api/collections/[id]/items/[itemId]/route.ts
+++ b/src/app/api/collections/[id]/items/[itemId]/route.ts
@@ -165,7 +165,7 @@ export async function PUT(
           name,
           initial,
           location,
-          country
+          region
         ),
         programs (
           id,

--- a/src/app/api/collections/[id]/items/route.ts
+++ b/src/app/api/collections/[id]/items/route.ts
@@ -113,7 +113,7 @@ export async function POST(
           name,
           initial,
           location,
-          country
+          region
         ),
         programs (
           id,

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -38,7 +38,7 @@ export async function GET(
             name,
             initial,
             location,
-            country
+            region
           ),
           programs (
             id,

--- a/src/app/programs/[id]/page.tsx
+++ b/src/app/programs/[id]/page.tsx
@@ -32,7 +32,7 @@ async function getProgram(id: string) {
         initial,
         type,
         location,
-        country,
+        region,
         qs_ranking,
         website_url
       ),
@@ -334,10 +334,10 @@ export default async function ProgramDetailPage({ params }: { params: Promise<{ 
                   <p>{program.schools.location}</p>
                 </div>
               )}
-              {program.schools.country && (
+              {program.schools.region && (
                 <div>
                   <h4 className="font-semibold text-gray-700">Country</h4>
-                  <p>{program.schools.country}</p>
+                  <p>{program.schools.region}</p>
                 </div>
               )}
             </div>

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -18,7 +18,7 @@ async function getProgramsWithRatings() {
         name,
         initial,
         location,
-        country
+        region
       )
     `)
     .order('name')

--- a/src/app/schools/[id]/page.tsx
+++ b/src/app/schools/[id]/page.tsx
@@ -226,10 +226,10 @@ export default async function SchoolDetailPage({ params }: { params: Promise<{ i
                 <p>{school.location}</p>
               </div>
             )}
-            {school.country && (
+            {school.region && (
               <div>
-                <h4 className="font-semibold text-gray-700">Country</h4>
-                <p>{school.country}</p>
+                <h4 className="font-semibold text-gray-700">Region</h4>
+                <p>{school.region}</p>
               </div>
             )}
             {school.year_founded && (

--- a/src/app/schools/page.tsx
+++ b/src/app/schools/page.tsx
@@ -129,7 +129,7 @@ export default async function SchoolsPage(props: {
                 <div className="space-y-2 text-sm text-gray-600 mb-4 flex-grow">
                   {school.type && <p><strong>Type:</strong> {school.type}</p>}
                   {school.location && <p><strong>Location:</strong> {school.location}</p>}
-                  {school.country && <p><strong>Country:</strong> {school.country}</p>}
+                  {school.region && <p><strong>Region:</strong> {school.region}</p>}
                   {school.year_founded && <p><strong>Founded:</strong> {school.year_founded}</p>}
                 </div>
                 

--- a/src/components/admin/programs-management.tsx
+++ b/src/components/admin/programs-management.tsx
@@ -47,6 +47,9 @@ interface Program {
   location?: string
   add_ons?: Record<string, unknown>
   start_date?: string
+  // New optional fields aligned with schema enhancements
+  application_difficulty?: 'SSR' | 'SR' | 'R' | 'N'
+  difficulty_description?: string
   schools?: School
   requirements?: Requirements
 }
@@ -316,13 +319,21 @@ export default function ProgramsManagement({ initialPrograms, schools }: Program
                   
                   <div>
                     <Label htmlFor="edit-degree">Degree *</Label>
-                    <Input 
+                    <select 
                       id="edit-degree" 
                       name="degree" 
-                      placeholder="e.g., MS, PhD, BS" 
+                      className="w-full p-2 border border-gray-300 rounded-md"
                       defaultValue={editingProgram.degree}
                       required 
-                    />
+                    >
+                      <option value="">Select degree</option>
+                      <option value="Bachelor">Bachelor</option>
+                      <option value="Master">Master</option>
+                      <option value="PhD">PhD</option>
+                      <option value="Associate">Associate</option>
+                      <option value="Certificate">Certificate</option>
+                      <option value="Diploma">Diploma</option>
+                    </select>
                   </div>
                   
                   <div className="md:col-span-2">
@@ -341,6 +352,31 @@ export default function ProgramsManagement({ initialPrograms, schools }: Program
               <div className="border rounded-lg p-4">
                 <h3 className="text-lg font-semibold mb-4">Program Details</h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="edit-application_difficulty">Application Difficulty</Label>
+                    <select 
+                      id="edit-application_difficulty" 
+                      name="application_difficulty" 
+                      className="w-full p-2 border border-gray-300 rounded-md"
+                      defaultValue={editingProgram.application_difficulty || ''}
+                    >
+                      <option value="">Select difficulty</option>
+                      <option value="SSR">SSR</option>
+                      <option value="SR">SR</option>
+                      <option value="R">R</option>
+                      <option value="N">N</option>
+                    </select>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="edit-difficulty_description">Difficulty Description</Label>
+                    <Textarea 
+                      id="edit-difficulty_description" 
+                      name="difficulty_description" 
+                      rows={2} 
+                      defaultValue={editingProgram.difficulty_description || ''}
+                    />
+                  </div>
                   <div>
                     <Label htmlFor="edit-duration_years">Duration (years)</Label>
                     <Input 
@@ -383,6 +419,7 @@ export default function ProgramsManagement({ initialPrograms, schools }: Program
                       <option value="Onsite">Onsite</option>
                       <option value="Online">Online</option>
                       <option value="Hybrid">Hybrid</option>
+                      <option value="Flexible">Flexible</option>
                     </select>
                   </div>
                   
@@ -397,6 +434,7 @@ export default function ProgramsManagement({ initialPrograms, schools }: Program
                       <option value="">Select schedule type</option>
                       <option value="Full-time">Full-time</option>
                       <option value="Part-time">Part-time</option>
+                      <option value="Flexible">Flexible</option>
                     </select>
                   </div>
                   

--- a/src/components/admin/programs-management.tsx
+++ b/src/components/admin/programs-management.tsx
@@ -103,6 +103,8 @@ export default function ProgramsManagement({ initialPrograms, schools }: Program
         delivery_method: formData.get('delivery_method') as string,
         schedule_type: formData.get('schedule_type') as string,
         location: formData.get('location') as string,
+        application_difficulty: (formData.get('application_difficulty') as string) || null,
+        difficulty_description: (formData.get('difficulty_description') as string) || null,
         add_ons: addOns,
         start_date: formData.get('start_date') as string || null,
         // Requirements
@@ -352,31 +354,6 @@ export default function ProgramsManagement({ initialPrograms, schools }: Program
               <div className="border rounded-lg p-4">
                 <h3 className="text-lg font-semibold mb-4">Program Details</h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="edit-application_difficulty">Application Difficulty</Label>
-                    <select 
-                      id="edit-application_difficulty" 
-                      name="application_difficulty" 
-                      className="w-full p-2 border border-gray-300 rounded-md"
-                      defaultValue={editingProgram.application_difficulty || ''}
-                    >
-                      <option value="">Select difficulty</option>
-                      <option value="SSR">SSR</option>
-                      <option value="SR">SR</option>
-                      <option value="R">R</option>
-                      <option value="N">N</option>
-                    </select>
-                  </div>
-
-                  <div>
-                    <Label htmlFor="edit-difficulty_description">Difficulty Description</Label>
-                    <Textarea 
-                      id="edit-difficulty_description" 
-                      name="difficulty_description" 
-                      rows={2} 
-                      defaultValue={editingProgram.difficulty_description || ''}
-                    />
-                  </div>
                   <div>
                     <Label htmlFor="edit-duration_years">Duration (years)</Label>
                     <Input 
@@ -632,6 +609,32 @@ export default function ProgramsManagement({ initialPrograms, schools }: Program
                       name="other_tests" 
                       placeholder="e.g., GMAT, SAT" 
                       defaultValue={editingProgram.requirements?.other_tests || ''}
+                    />
+                  </div>
+
+                  <div>
+                    <Label htmlFor="edit-application_difficulty">Application Difficulty</Label>
+                    <select 
+                      id="edit-application_difficulty" 
+                      name="application_difficulty" 
+                      className="w-full p-2 border border-gray-300 rounded-md"
+                      defaultValue={editingProgram.application_difficulty || ''}
+                    >
+                      <option value="">Select difficulty</option>
+                      <option value="SSR">SSR</option>
+                      <option value="SR">SR</option>
+                      <option value="R">R</option>
+                      <option value="N">N</option>
+                    </select>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="edit-difficulty_description">Difficulty Description</Label>
+                    <Textarea 
+                      id="edit-difficulty_description" 
+                      name="difficulty_description" 
+                      rows={2} 
+                      defaultValue={editingProgram.difficulty_description || ''}
                     />
                   </div>
                   

--- a/src/components/admin/schools-management.tsx
+++ b/src/components/admin/schools-management.tsx
@@ -12,7 +12,7 @@ interface School {
   name: string
   initial?: string
   type?: string
-  country?: string
+  region?: string
   location?: string
   year_founded?: number
   qs_ranking?: number
@@ -45,7 +45,7 @@ export default function SchoolsManagement({ initialSchools }: SchoolsManagementP
         name: formData.get('name') as string,
         initial: formData.get('initial') as string,
         type: formData.get('type') as string,
-        country: formData.get('country') as string,
+        region: formData.get('region') as string,
         location: formData.get('location') as string,
         year_founded: formData.get('year_founded') ? parseInt(formData.get('year_founded') as string) : null,
         qs_ranking: formData.get('qs_ranking') ? parseInt(formData.get('qs_ranking') as string) : null,
@@ -203,21 +203,36 @@ export default function SchoolsManagement({ initialSchools }: SchoolsManagementP
               
               <div>
                 <Label htmlFor="edit-type">Type</Label>
-                <Input 
+                <select 
                   id="edit-type" 
                   name="type" 
-                  placeholder="e.g., University" 
+                  className="w-full p-2 border border-gray-300 rounded-md"
                   defaultValue={editingSchool.type || ''}
-                />
+                >
+                  <option value="">Select type</option>
+                  <option value="Public">Public</option>
+                  <option value="Private">Private</option>
+                  <option value="Art & Design">Art & Design</option>
+                  <option value="Community College">Community College</option>
+                </select>
               </div>
               
               <div>
-                <Label htmlFor="edit-country">Country</Label>
-                <Input 
-                  id="edit-country" 
-                  name="country" 
-                  defaultValue={editingSchool.country || ''}
-                />
+                <Label htmlFor="edit-region">Region</Label>
+                <select 
+                  id="edit-region" 
+                  name="region" 
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  defaultValue={editingSchool.region || ''}
+                >
+                  <option value="">Select region</option>
+                  <option value="United States">United States</option>
+                  <option value="United Kingdom">United Kingdom</option>
+                  <option value="Canada">Canada</option>
+                  <option value="Europe">Europe</option>
+                  <option value="Asia">Asia</option>
+                  <option value="Australia">Australia</option>
+                </select>
               </div>
               
               <div>

--- a/src/components/navigation-client.tsx
+++ b/src/components/navigation-client.tsx
@@ -1,15 +1,46 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import type { MouseEvent } from 'react'
 import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
 import type { User } from '@supabase/supabase-js'
+import { LogOut } from 'lucide-react'
 
 export function NavigationClient() {
   const [user, setUser] = useState<User | null>(null)
   const [isAdmin, setIsAdmin] = useState(false)
   const [loading, setLoading] = useState(true)
+  const router = useRouter()
+  const [openSchools, setOpenSchools] = useState(false)
+  const [openPrograms, setOpenPrograms] = useState(false)
+  const [openAccount, setOpenAccount] = useState(false)
+  
+  const handleLogoutClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    const confirmed = typeof window === 'undefined' ? true : window.confirm('Are you sure you want to log out?')
+    if (confirmed) {
+      const form = e.currentTarget.closest('form') as HTMLFormElement | null
+      form?.submit()
+    }
+  }
+
+  const regions = [
+    'United States',
+    'United Kingdom',
+    'Canada',
+    'Europe',
+    'Asia',
+    'Australia',
+  ] as const
 
   useEffect(() => {
     const supabase = createClient()
@@ -74,38 +105,93 @@ export function NavigationClient() {
       {user ? (
         // Authenticated user navigation
         <>
-          <Button asChild variant="ghost">
-            <Link href="/schools">Schools</Link>
-          </Button>
-          <Button asChild variant="ghost">
-            <Link href="/programs">Programs</Link>
-          </Button>
-          <Button asChild variant="ghost">
-            <Link href="/collections">My Collections</Link>
-          </Button>
-          <Button asChild variant="ghost">
-            <Link href="/profile">Profile</Link>
-          </Button>
-          {isAdmin && (
-            <Button asChild variant="ghost">
-              <Link href="/admin/dashboard">Admin</Link>
-            </Button>
-          )}
-          <form action="/api/auth/logout" method="post">
-            <Button type="submit" variant="secondary" size="sm" className="cursor-pointer">
-              Logout
-            </Button>
-          </form>
+          <div onMouseEnter={() => setOpenSchools(true)} onMouseLeave={() => setOpenSchools(false)}>
+            <DropdownMenu open={openSchools} onOpenChange={setOpenSchools}>
+              <DropdownMenuTrigger asChild>
+                <Button asChild variant="ghost"><Link href="/schools">Schools</Link></Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+              {regions.map((r) => (
+                <DropdownMenuItem key={r} onClick={() => router.push(`/schools?search=${encodeURIComponent(r)}`)}>
+                  {r}
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuItem onClick={() => router.push('/schools')}>All Regions</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div onMouseEnter={() => setOpenPrograms(true)} onMouseLeave={() => setOpenPrograms(false)}>
+            <DropdownMenu open={openPrograms} onOpenChange={setOpenPrograms}>
+              <DropdownMenuTrigger asChild>
+                <Button asChild variant="ghost"><Link href="/programs">Programs</Link></Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+              {regions.map((r) => (
+                <DropdownMenuItem key={r} onClick={() => router.push(`/programs?search=${encodeURIComponent(r)}`)}>
+                  {r}
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuItem onClick={() => router.push('/programs')}>All Regions</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div onMouseEnter={() => setOpenAccount(true)} onMouseLeave={() => setOpenAccount(false)}>
+            <DropdownMenu open={openAccount} onOpenChange={setOpenAccount}>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="cursor-pointer">Account</Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem onClick={() => router.push('/profile')}>Profile</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => router.push('/collections')}>Collections</DropdownMenuItem>
+                {isAdmin && (
+                  <DropdownMenuItem onClick={() => router.push('/admin/dashboard')}>Admin</DropdownMenuItem>
+                )}
+                <DropdownMenuItem asChild>
+                  <form action="/api/auth/logout" method="post" className="w-full">
+                    <button type="button" onClick={handleLogoutClick} className="flex items-center gap-2">
+                      <span>Logout</span>
+                      <LogOut className="w-4 h-4" />
+                    </button>
+                  </form>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          
         </>
       ) : (
         // Guest navigation
         <>
-          <Button asChild variant="ghost">
-            <Link href="/schools">Schools</Link>
-          </Button>
-          <Button asChild variant="ghost">
-            <Link href="/programs">Programs</Link>
-          </Button>
+          <div onMouseEnter={() => setOpenSchools(true)} onMouseLeave={() => setOpenSchools(false)}>
+            <DropdownMenu open={openSchools} onOpenChange={setOpenSchools}>
+              <DropdownMenuTrigger asChild>
+                <Button asChild variant="ghost"><Link href="/schools">Schools</Link></Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+              {regions.map((r) => (
+                <DropdownMenuItem key={r} onClick={() => router.push(`/schools?search=${encodeURIComponent(r)}`)}>
+                  {r}
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuItem onClick={() => router.push('/schools')}>All Regions</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div onMouseEnter={() => setOpenPrograms(true)} onMouseLeave={() => setOpenPrograms(false)}>
+            <DropdownMenu open={openPrograms} onOpenChange={setOpenPrograms}>
+              <DropdownMenuTrigger asChild>
+                <Button asChild variant="ghost"><Link href="/programs">Programs</Link></Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+              {regions.map((r) => (
+                <DropdownMenuItem key={r} onClick={() => router.push(`/programs?search=${encodeURIComponent(r)}`)}>
+                  {r}
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuItem onClick={() => router.push('/programs')}>All Regions</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
           <Button asChild variant="ghost">
             <Link href="/login">Login</Link>
           </Button>

--- a/src/lib/admin-search.ts
+++ b/src/lib/admin-search.ts
@@ -199,15 +199,15 @@ export function simpleFilterItems<T extends SearchableItem>(
  */
 export const searchConfigs = {
   schools: {
-    fields: ['name', 'initial', 'type', 'country', 'location'],
-    placeholder: 'Search schools by name, abbreviation, type, country, or location...',
-    helpText: 'Search works on: school names, abbreviations (e.g. "CMU"), type, country, and location'
+    fields: ['name', 'initial', 'type', 'region', 'location'],
+    placeholder: 'Search schools by name, abbreviation, type, region, or location...',
+    helpText: 'Search works on: school names, abbreviations (e.g. "CMU"), type, region, and location'
   },
   
   programs: {
-    fields: ['name', 'initial', 'degree', 'schools.name', 'schools.initial', 'description'],
-    placeholder: 'Search programs by name, abbreviation, degree, school, or description...',
-    helpText: 'Search works on: program names, abbreviations, degrees, school names/abbreviations, and descriptions'
+    fields: ['name', 'initial', 'degree', 'schools.name', 'schools.initial', 'schools.region', 'description'],
+    placeholder: 'Search programs by name, abbreviation, degree, school, region, or description...',
+    helpText: 'Search works on: program names, abbreviations, degrees, school names/abbreviations, regions, and descriptions'
   },
   
   users: {

--- a/src/lib/types/schema-enhancements.ts
+++ b/src/lib/types/schema-enhancements.ts
@@ -1,0 +1,247 @@
+/**
+ * TypeScript types and interfaces
+ * Includes program categories, multiple rankings, and application difficulty
+ */
+
+
+// ============================================================================
+// APPLICATION DIFFICULTY
+// ============================================================================
+
+export type ApplicationDifficulty = 'SSR' | 'SR' | 'R' | 'N'
+
+export interface DifficultyInfo {
+  level: ApplicationDifficulty
+  label: string
+  description: string
+  color: string
+  acceptanceRate: string
+}
+
+export const DIFFICULTY_LEVELS: Record<ApplicationDifficulty, DifficultyInfo> = {
+  SSR: {
+    level: 'SSR',
+    label: 'Super Super Rare',
+    description: 'Extremely competitive programs with < 5% acceptance rate',
+    color: '#FF6B6B',
+    acceptanceRate: '< 5%'
+  },
+  SR: {
+    level: 'SR',
+    label: 'Super Rare',
+    description: 'Highly competitive programs with 5-15% acceptance rate',
+    color: '#4ECDC4',
+    acceptanceRate: '5-15%'
+  },
+  R: {
+    level: 'R',
+    label: 'Rare',
+    description: 'Competitive programs with 15-30% acceptance rate',
+    color: '#45B7D1',
+    acceptanceRate: '15-30%'
+  },
+  N: {
+    level: 'N',
+    label: 'Normal',
+    description: 'Standard programs with > 30% acceptance rate',
+    color: '#96CEB4',
+    acceptanceRate: '> 30%'
+  }
+}
+
+// ============================================================================
+// ENHANCED PROGRAM INTERFACE
+// ============================================================================
+
+export interface EnhancedProgram {
+  id: string
+  name: string
+  initial?: string
+  school_id: string
+  degree: string
+  website_url?: string
+  duration_years?: number
+  currency?: string
+  total_tuition?: number
+  is_stem: boolean
+  description?: string
+  credits?: number
+  delivery_method?: string
+  schedule_type?: string
+  location?: string
+  add_ons?: Record<string, unknown>
+  start_date?: string
+  
+  // New fields for Issue #69
+  application_difficulty?: ApplicationDifficulty
+  difficulty_description?: string
+  
+  // Related data
+  school?: {
+    id: string
+    name: string
+    initial?: string
+    location?: string
+    country?: string
+  }
+  requirements?: {
+    id: string
+    ielts_score?: number
+    toefl_score?: number
+    gre_score?: number
+    min_gpa?: number
+    other_tests?: string
+    requires_personal_statement?: boolean
+    requires_portfolio?: boolean
+    requires_cv?: boolean
+    letters_of_recommendation?: number
+    application_fee?: number
+    application_deadline?: string
+  }
+  
+  created_by?: string
+  created_at: string
+}
+
+// ============================================================================
+// ENHANCED SCHOOL INTERFACE
+// ============================================================================
+
+export interface EnhancedSchool {
+  id: string
+  name: string
+  initial?: string
+  type?: string
+  region?: string
+  location?: string
+  year_founded?: number
+  qs_ranking?: number // Keep for backward compatibility
+  website_url?: string
+  
+  created_by?: string
+  created_at: string
+}
+
+// ============================================================================
+// FORM DATA TYPES
+// ============================================================================
+
+export interface ProgramCategoryFormData {
+  name: string
+  description?: string
+  career_path?: string
+  icon?: string
+  color?: string
+}
+
+export interface ProgramFormData {
+  name: string
+  initial?: string
+  school_id: string
+  degree: string
+  website_url?: string
+  duration_years?: number
+  currency?: string
+  total_tuition?: number
+  is_stem: boolean
+  description?: string
+  credits?: number
+  delivery_method?: string
+  schedule_type?: string
+  location?: string
+  add_ons?: Record<string, unknown>
+  start_date?: string
+  
+  // New fields for Issue #69
+  application_difficulty?: ApplicationDifficulty
+  difficulty_description?: string
+}
+
+// 暂时不实现多排名源系统
+
+// ============================================================================
+// SEARCH AND FILTER TYPES
+// ============================================================================
+
+export interface ProgramSearchFilters {
+  search?: string
+  difficulty?: ApplicationDifficulty[]
+  degree?: string[]
+  delivery_method?: string[]
+  schedule_type?: string[]
+  is_stem?: boolean
+  min_tuition?: number
+  max_tuition?: number
+  min_duration?: number
+  max_duration?: number
+  region?: string[]
+}
+
+export interface SchoolSearchFilters {
+  search?: string
+  country?: string[]
+  type?: string[]
+  year_founded_min?: number
+  year_founded_max?: number
+}
+
+// ============================================================================
+// API RESPONSE TYPES
+// ============================================================================
+
+// (Phase 2 categories response removed)
+
+// 暂时不实现多排名源系统
+
+export interface EnhancedProgramsResponse {
+  programs: EnhancedProgram[]
+  total: number
+  filters: ProgramSearchFilters
+}
+
+export interface EnhancedSchoolsResponse {
+  schools: EnhancedSchool[]
+  total: number
+  filters: SchoolSearchFilters
+}
+
+// ============================================================================
+// UTILITY TYPES
+// ============================================================================
+
+// (Phase 2 category stats removed)
+
+export interface DifficultyStats {
+  difficulty: ApplicationDifficulty
+  count: number
+  percentage: number
+}
+
+// ============================================================================
+// VALIDATION SCHEMAS (for use with Zod)
+// ============================================================================
+
+export const APPLICATION_DIFFICULTY_VALUES = ['SSR', 'SR', 'R', 'N'] as const
+
+// (Phase 2 career paths constants removed)
+
+export const DELIVERY_METHODS = [
+  'Onsite',
+  'Online', 
+  'Hybrid'
+] as const
+
+export const SCHEDULE_TYPES = [
+  'Full-time',
+  'Part-time',
+  'Flexible'
+] as const
+
+export const DEGREE_TYPES = [
+  'Bachelor',
+  'Master',
+  'PhD',
+  'Associate',
+  'Certificate',
+  'Diploma'
+] as const

--- a/supabase/migrations/0009_add_program_difficulty.sql
+++ b/supabase/migrations/0009_add_program_difficulty.sql
@@ -1,0 +1,38 @@
+-- Add application difficulty fields to programs
+
+ALTER TABLE programs 
+ADD COLUMN application_difficulty VARCHAR(10) CHECK (application_difficulty IN ('SSR', 'SR', 'R', 'N')),
+ADD COLUMN difficulty_description TEXT;
+
+COMMENT ON COLUMN programs.application_difficulty IS 'Application difficulty: SSR (Super Super Rare), SR (Super Rare), R (Rare), N (Normal)';
+COMMENT ON COLUMN programs.difficulty_description IS 'Human-readable description of application difficulty';
+
+CREATE INDEX idx_programs_application_difficulty ON programs(application_difficulty);
+
+-- Normalize schools.country -> region enum
+
+-- Create enum for region values (standardized)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'region_type') THEN
+    CREATE TYPE region_type AS ENUM ('United States', 'United Kingdom', 'Canada', 'Europe', 'Asia', 'Australia', 'Other');
+  END IF;
+END $$;
+
+-- Rename and migrate
+ALTER TABLE public.schools RENAME COLUMN country TO region_text;
+ALTER TABLE public.schools ADD COLUMN region region_type;
+
+UPDATE public.schools
+SET region = (CASE
+  WHEN region_text ILIKE 'us' OR region_text ILIKE 'usa' OR region_text ILIKE 'u.s.' OR region_text ILIKE 'united states%' OR region_text ILIKE 'america' THEN 'United States'
+  WHEN region_text ILIKE 'uk' OR region_text ILIKE 'united kingdom%' OR region_text ILIKE 'great britain' OR region_text ILIKE 'england' OR region_text ILIKE 'scotland' OR region_text ILIKE 'wales' OR region_text ILIKE 'northern ireland' THEN 'United Kingdom'
+  WHEN region_text ILIKE 'eu' OR region_text ILIKE 'europe%' OR region_text ILIKE '%germany%' OR region_text ILIKE '%france%' OR region_text ILIKE '%spain%' OR region_text ILIKE '%italy%' OR region_text ILIKE '%netherlands%' OR region_text ILIKE '%sweden%' OR region_text ILIKE '%finland%' OR region_text ILIKE '%denmark%' OR region_text ILIKE '%norway%' THEN 'Europe'
+  WHEN region_text ILIKE 'asia%' OR region_text ILIKE '%china%' OR region_text ILIKE '%japan%' OR region_text ILIKE '%korea%' OR region_text ILIKE '%india%' OR region_text ILIKE '%singapore%' OR region_text ILIKE '%hong kong%' OR region_text ILIKE '%taiwan%' OR region_text ILIKE '%malaysia%' OR region_text ILIKE '%thailand%' OR region_text ILIKE '%indonesia%' OR region_text ILIKE '%vietnam%' THEN 'Asia'
+  WHEN region_text ILIKE '%australia%' THEN 'Australia'
+  WHEN region_text ILIKE 'canada' OR region_text ILIKE '%ontario%' OR region_text ILIKE '%quebec%' OR region_text ILIKE '%british columbia%' OR region_text ILIKE '%alberta%' OR region_text ILIKE '%manitoba%' OR region_text ILIKE '%saskatchewan%' OR region_text ILIKE '%nova scotia%' OR region_text ILIKE '%new brunswick%' OR region_text ILIKE '%newfoundland%' OR region_text ILIKE '%prince edward island%' THEN 'Canada'
+  ELSE 'Other'
+END)::region_type;
+
+-- Keep region_text temporarily to avoid breaking dependent views. Drop in a follow-up after views are updated.
+-- ALTER TABLE public.schools DROP COLUMN region_text;
+CREATE INDEX IF NOT EXISTS idx_schools_region ON public.schools(region);

--- a/supabase/migrations/0010_normalize_school_types.sql
+++ b/supabase/migrations/0010_normalize_school_types.sql
@@ -1,0 +1,73 @@
+-- Normalize existing values in schools.type to one of:
+--   Public | Private | Art & Design | Community College
+--
+-- Safe to run multiple times. Uses pattern-based updates.
+
+begin;
+
+-- Trim whitespace first
+update public.schools
+set type = btrim(type)
+where type is not null;
+
+-- Public
+update public.schools
+set type = 'Public'
+where type is not null
+  and type <> 'Public'
+  and (
+    type ~* '(?<![a-z])public(?![a-z])' or
+    type ~* '(?<![a-z])state(?![a-z])' or
+    type ~* 'state university' or
+    type ~* 'government' or
+    type ~* '(?<![a-z])govt(?![a-z])'
+  );
+
+-- Private
+update public.schools
+set type = 'Private'
+where type is not null
+  and type <> 'Private'
+  and (
+    type ~* '(?<![a-z])private(?![a-z])' or
+    type ~* 'independent' or
+    type ~* 'non[- ]?profit' or
+    type ~* 'for[- ]?profit'
+  );
+
+-- Art & Design
+update public.schools
+set type = 'Art & Design'
+where type is not null
+  and type <> 'Art & Design'
+  and (
+    type ~* 'art\s*&\s*design' or
+    type ~* 'art\s*and\s*design' or
+    type ~* 'art-?and-?design' or
+    type ~* 'school of design' or
+    type ~* 'college of art' or
+    type ~* 'visual arts' or
+    type ~* 'design school' or
+    type ~* 'arts college' or
+    type ~* '(?<![a-z])artanddesign(?![a-z])'
+  );
+
+-- Community College
+update public.schools
+set type = 'Community College'
+where type is not null
+  and type <> 'Community College'
+  and (
+    type ~* 'community college' or
+    type ~* 'junior college' or
+    type ~* '(2|two)[- ]?year' or
+    type ~* '(?<![a-z])cc(?![a-z])'
+  );
+
+commit;
+
+-- Note: Consider later adding a CHECK constraint or enum if you want to enforce
+-- allowable values at the schema level. For now this migration only normalizes
+-- existing rows.
+
+

--- a/supabase/migrations/0011_normalize_program_degrees.sql
+++ b/supabase/migrations/0011_normalize_program_degrees.sql
@@ -1,0 +1,69 @@
+-- Normalize program degree values to a standard set
+-- Target values: Bachelor | Master | PhD | Associate | Certificate | Diploma
+-- Idempotent and safe to run multiple times.
+
+begin;
+
+-- Trim whitespace
+update public.programs
+set degree = btrim(degree)
+where degree is not null;
+
+-- Master variants
+update public.programs
+set degree = 'Master'
+where degree is not null
+  and degree <> 'Master'
+  and (
+    degree ~* '^(ms|m\.s\.|m sc|m\. sc\.|master|masters)$' or
+    degree ~* 'm[a\.]?s(?![a-z])'
+  );
+
+-- Bachelor variants
+update public.programs
+set degree = 'Bachelor'
+where degree is not null
+  and degree <> 'Bachelor'
+  and (
+    degree ~* '^(bs|b\.s\.|b sc|b\. sc\.|bachelor|bachelors)$' or
+    degree ~* 'b[a\.]?s(?![a-z])'
+  );
+
+-- PhD variants
+update public.programs
+set degree = 'PhD'
+where degree is not null
+  and degree <> 'PhD'
+  and (
+    degree ~* '^(phd|ph\.d\.|doctorate|doctoral)$'
+  );
+
+-- Associate variants
+update public.programs
+set degree = 'Associate'
+where degree is not null
+  and degree <> 'Associate'
+  and (
+    degree ~* '^(associate|aas|a\.a\.s\.)$'
+  );
+
+-- Certificate variants
+update public.programs
+set degree = 'Certificate'
+where degree is not null
+  and degree <> 'Certificate'
+  and (
+    degree ~* '^(certificate|cert)$'
+  );
+
+-- Diploma variants
+update public.programs
+set degree = 'Diploma'
+where degree is not null
+  and degree <> 'Diploma'
+  and (
+    degree ~* '^(diploma)$'
+  );
+
+commit;
+


### PR DESCRIPTION
## Summary
This PR combines earlier and new changes. It includes the previously merged commits on this branch and adds degree normalization + CSV difficulty updates.

Included changes:
- Navigation
  - Account dropdown (Profile, Collections, Admin, Logout) with hover behavior
  - Region dropdowns under Schools/Programs; click shows all, hover filters by region
  - Logout confirmation dialog and icon styling
- Admin UI
  - Schools: Region + Type as selects (Type: Public, Private, Art & Design, Community College)
  - Programs: selects for Degree, Delivery, Schedule; Application Difficulty + description; moved difficulty under Admission Requirements in add/edit
- CSV Upload
  - Programs CSV now documents normalized degree values and sends application_difficulty + difficulty_description
  - Schools CSV expects region (enum values without Other)
- Search
  - Program search includes schools.region
- Migrations
  - 0010: Normalize school types
  - 0011: Normalize program degrees (e.g., MS/master -> Master, BS -> Bachelor)
- Tests
  - Added coverage for Account/Logout + schema-enhancements; full suite passing

<img width="1383" height="824" alt="Screenshot 2025-09-19 at 02 17 28" src="https://github.com/user-attachments/assets/8607ebaf-7184-46c1-805a-64006a105a1b" />
<img width="1329" height="807" alt="Screenshot 2025-09-19 at 02 17 37" src="https://github.com/user-attachments/assets/43d66086-1038-426e-afe2-d8d44c2abad8" />
<img width="1276" height="268" alt="Screenshot 2025-09-19 at 03 10 31" src="https://github.com/user-attachments/assets/23afe59a-1921-488e-ae2d-b68a13ee7e89" />


Closes #81, Closes #70

All tests passing: 498/498.
